### PR TITLE
add production mender state scripts

### DIFF
--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/restore
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/restore
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+echo "state-script version: 1" >&2
+#
+# Settings (used both in backup and restore)
+#
+
+EXIT_OK=0
+
+#
+# reconnect mappers (to enforce regeneration of bridge files (to add/remove values as required))
+#
+# FIXME: Don't execute reconnect as reconnecting will restart the tedge-agent!
+# Enable once https://github.com/thin-edge/thin-edge.io/issues/2494 is resolved
+# MAPPERS="c8y az aws"
+# for name in $MAPPERS; do
+#     if [ -n "$(tedge config get "${name}.url" 2>/dev/null)" ]; then
+#         # Try reconnecting, but ignore any failures as it could be due to connectivity problems, and these are detected downstream
+#         # using a proper retry mechanism
+#         tedge reconnect "${name}" >&2 || true
+#     else
+#         echo "Skipping mapper as it is not configured. ${name}" >&2
+#     fi
+# done
+
+exit "$EXIT_OK"

--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/tedge-commit-enter-script
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/tedge-commit-enter-script
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-
-if [ -d /data/etc_tedge ]; then
-    cp -fr /data/etc_tedge/* /etc/tedge && rm -fr /data/etc_tedge  
-fi
-
-if [ -d /data/var_tedge ]; then
-    cp -fr /data/var_tedge/* /var/tedge && rm -fr /data/var_tedge
-fi

--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/tedge-install-leave-script
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/tedge-install-leave-script
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-
-if [ -n  "$(ls -A /etc/tedge/)" ]; then
-    mkdir -p /data/etc_tedge && cp -fr /etc/tedge/* /data/etc_tedge
-fi
-
-if [ -n  "$(ls -A /var/tedge/)" ]; then
-    mkdir -p /data/var_tedge && cp -fr /var/tedge/* /data/var_tedge
-fi

--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/transfer
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/transfer
@@ -1,0 +1,194 @@
+#!/bin/sh
+set -e
+echo "state-script version: 5" >&2
+
+# Use trap to unmount in case of unexpected errors
+# unmount using mountpoint rather than device (in case it is mounted elsewhere)
+trap_exit() {
+    echo "Unmounting"
+    sync "/tmp/inactive_part" ||:
+
+    # TODO: calling umount hangs here!
+    umount -l /tmp/inactive_part &
+    i=0
+    while [ "$i" -lt 5 ]; do
+        if ! mountpoint -q /tmp/inactive_part; then
+            echo "inactive partition has been unmounted"
+            break
+        fi
+        i=$((i + 1))
+        sleep 1
+    done
+    # Force killing of any user using the mount (which might cause shutdown stalling)
+    fuser -mk /tmp/inactive_part ||:
+}
+trap trap_exit EXIT
+
+progress() {
+    echo "$@"
+    echo "$@" >&2
+}
+
+MENDER_ROOTFS_PART_A="/dev/mmcblk0p2"
+MENDER_ROOTFS_PART_B="/dev/mmcblk0p3"
+
+#
+# Retain ssh server keys from the current root
+#
+if mount | grep "${MENDER_ROOTFS_PART_A} on / "; then
+  inactive_part="${MENDER_ROOTFS_PART_B}"
+else
+  inactive_part="${MENDER_ROOTFS_PART_A}"
+fi
+
+target="/tmp/inactive_part"
+progress "Mounting ${inactive_part} to ${target}"
+mkdir -p "${target}"
+
+# DEBUG: Wait before mounting (to give time for the partition write to finish?)
+sleep 5
+# mount -o ro ${inactive_part} /tmp/inactive_part
+mount ${inactive_part} "${target}"
+progress "Mounted ${inactive_part} to ${target}"
+
+# Save core services as presets
+progress "Saving presets"
+
+# Note: ||: is needed as this can fail if the file does not exist (even when using rm -f!)
+# This might be a combination of a busybox thing and/or the way the volume is mounted
+rm -f "${target}/etc/systemd/system-preset/98-thin-edge.preset" ||:
+mkdir -p "${target}/etc/systemd/system-preset"
+systemctl list-unit-files | grep enabled | grep -E "^tedge|^c8y|^mosquitto" | cut -d\  -f1 | while read -r UNIT_NAME; do
+    progress "Adding $UNIT_NAME to service preset"
+    echo "enable $UNIT_NAME" >> "${target}/etc/systemd/system-preset/98-thin-edge.preset"
+done
+
+
+# WORKAROUND: Copy systemd symlinks so that the agent is enable by default
+# Check if this causes a problem if the service does not exist in the new image
+if [ -e /etc/systemd/system/multi-user.target.wants/tedge-agent.service ]; then
+    progress "Copying thin-edge.io services symlink to enable services on startup"
+
+    if ls /etc/systemd/system/multi-user.target.wants/tedge* >/dev/null 2>&1; then
+        cp -af /etc/systemd/system/multi-user.target.wants/tedge* "${target}/etc/systemd/system/multi-user.target.wants/" || {
+            progress "Failed to copy tedge* services"
+            exit 1
+        }
+    fi
+
+    if ls /etc/systemd/system/multi-user.target.wants/c8y* >/dev/null 2>&1; then
+        cp -af /etc/systemd/system/multi-user.target.wants/c8y* "${target}/etc/systemd/system/multi-user.target.wants/" || {
+            progress "Failed to copy c8y* services"
+            exit 1
+        }
+    fi
+fi
+
+# sudoers
+if [ -d /etc/sudoers.d ]; then
+    progress "Copying sudoers.d config"
+    cp -af /etc/sudoers.d/* "${target}/etc/sudoers.d/"
+fi
+
+# mosquitto
+# Due to a race condition
+# if [ -d /var/lib/mosquitto ]; then
+#     # TODO: Check if mosquitto should be stopped instead
+#     # Tell mosquitto to write to file before copying the db
+#     progress "Sending SIGUSR1 to mosquitto to force writing to db (then wait a few seconds)"
+#     systemctl kill --signal=SIGUSR1 mosquitto.service
+#     sleep 5
+
+#     progress "Copying mosquitto db"
+#     mkdir -p "${target}/var/lib/mosquitto"
+#     chown -R mosquitto:mosquitto "${target}/var/lib/mosquitto"
+#     if ls /var/lib/mosquitto/* >/dev/null 2>&1; then
+#         cp -Rfa /var/lib/mosquitto/* "${target}/var/lib/mosquitto"
+#     fi
+# fi
+
+# tedge files
+if [ -d /etc/tedge ]; then
+    progress "Copying /etc/tedge"
+    if [ ! -d "${target}/etc/tedge" ]; then
+        mkdir -p "${target}/etc/tedge"
+        chown tedge:tedge "${target}/etc/tedge"
+    fi
+
+    if ls /etc/tedge/* >/dev/null 2>&1; then
+        progress "Copying /etc/tedge configuration"
+        cp -RfaH /etc/tedge/* "${target}/etc/tedge"
+    fi
+
+    # data files
+    VAR_TEDGE=$(tedge config get data.path)
+    NEW_VAR_TEDGE="${target}${VAR_TEDGE}"
+
+    progress "Copying $VAR_TEDGE"
+    if [ ! -d "$NEW_VAR_TEDGE" ]; then
+        mkdir -p "$NEW_VAR_TEDGE"
+        chown tedge:tedge "$NEW_VAR_TEDGE"
+    fi
+    if ls "$VAR_TEDGE"/* >/dev/null 2>&1; then
+        progress "Copying $VAR_TEDGE files"
+        cp -Rfa "$VAR_TEDGE"/* "$NEW_VAR_TEDGE"
+    fi
+fi
+
+# ssh authorized keys
+if [ -d /home/root/.ssh ]; then
+    if [ -f /home/root/.ssh/authorized_keys ]; then
+        if [ ! -f "${target}/home/root/.ssh/authorized_keys" ]; then
+            progress "Copying authorized_keys"
+            mkdir -p "${target}/home/root/.ssh"
+            chmod 700 "${target}/home/root/.ssh"
+
+            if ls "/home/root/.ssh/"* >/dev/null 2>&1; then
+                progress "Copying /home/root/.ssh/* files"
+                cp -Rfa /home/root/.ssh/* "${target}/home/root/.ssh/"
+            fi
+        else
+            progress "Found authorized_keys in new root, skipping copy"
+        fi
+    else
+        progress "No authorized keys in current root, skipping copy"
+    fi
+fi
+
+# ssh configuration
+SSH_SERVER_DIR=
+if [ -d "${target}/etc/ssh" ]; then
+    SSH_SERVER_DIR=etc/ssh
+elif [ -d "${target}/etc/dropbear" ]; then
+    SSH_SERVER_DIR=etc/dropbear
+fi
+
+if [ -n "$SSH_SERVER_DIR" ]; then
+    keys=$(ls -l "${target}/${SSH_SERVER_DIR}"/*key* 2>/dev/null | wc -l)
+
+    if [ "$keys" -eq 0 ]; then
+        progress "Copying ssh server key (/$SSH_SERVER_DIR)"
+        cp "/${SSH_SERVER_DIR}"/*key* "${target}/${SSH_SERVER_DIR}"
+    else
+        progress "Found ssh keys in new root, skipping copy"
+    fi
+else
+    progress "Failed to find a ssh server config on newroot partition"
+    exit 1
+fi
+
+# Backup systemd network files
+if [ -d "${target}/etc/systemd/network" ]; then
+    networks=$(ls -l "/etc/systemd/network/"*.network 2>/dev/null | wc -l)
+
+    if [ "$networks" -gt 0 ]; then
+        cp /etc/systemd/network/*.network "${target}/etc/systemd/network"
+        progress "Copied /etc/systemd/network"
+    fi
+else
+    progress "Failed to find a /etc/systemd/network on newroot partition"
+    exit 1
+fi
+
+progress "Finished"
+exit 0

--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/verify-tedge
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/verify-tedge
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+echo "state-script version: 1" >&2
+
+OK=0
+RETRY_LATER=21
+
+MAPPERS="c8y az aws"
+
+is_mapper_connected() {
+    CLOUD_MAPPER="$1"
+
+    if [ -n "$(tedge config get "$CLOUD_MAPPER.url" 2>/dev/null)" ]; then
+        tedge connect "$CLOUD_MAPPER" --test >&2
+    else
+        # If the configuration is not configured, then treat the device as healthy
+        echo "Mapper is not configured: $CLOUD_MAPPER" >&2
+        return 0
+    fi
+}
+
+all_healthy() {
+    # Check all mappers before returning, and fail if
+    # any of the configured mappers are not healthy
+    failed=0
+    for name in $MAPPERS; do
+        if ! is_mapper_connected "$name"; then
+            failed=1
+        fi
+    done
+
+    return "$failed"
+}
+
+if ! all_healthy; then
+    exit "$RETRY_LATER"
+fi
+
+exit "$OK"

--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts_1.0.bb
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts_1.0.bb
@@ -3,13 +3,15 @@ inherit mender-state-scripts
 LICENSE = "CLOSED"
 
 SRC_URI += " \
-    file://tedge-install-leave-script;subdir=${PN}-${PV} \
-    file://tedge-commit-enter-script;subdir=${PN}-${PV} \
+    file://transfer;subdir=${BPN}-${PV} \
+    file://restore;subdir=${BPN}-${PV} \
+    file://verify-tedge;subdir=${BPN}-${PV} \
 "
 
 do_compile() {
-    cp tedge-install-leave-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_00
-    cp tedge-commit-enter-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Enter_00
+    cp transfer ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_00_transfer
+    cp restore ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Enter_00_restore
+    cp verify-tedge ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Enter_50_verify-tedge
 }
 
 ALLOW_EMPTY:${PN} = "1"

--- a/recipes-core/images/core-image-tedge-mender.bb
+++ b/recipes-core/images/core-image-tedge-mender.bb
@@ -2,4 +2,6 @@ require core-image-tedge.bb
 
 IMAGE_INSTALL:append = " \
     tedge-state-scripts \
+    tedge-firmware \
+    ${@bb.utils.contains('INIT_MANAGER','systemd','tedge-bootstrap','',d)} \
 "

--- a/recipes-core/images/core-image-tedge-mender.bb
+++ b/recipes-core/images/core-image-tedge-mender.bb
@@ -5,3 +5,6 @@ IMAGE_INSTALL:append = " \
     tedge-firmware \
     ${@bb.utils.contains('INIT_MANAGER','systemd','tedge-bootstrap','',d)} \
 "
+
+# Add Network Manager
+IMAGE_INSTALL += "networkmanager networkmanager-bash-completion networkmanager-nmtui"

--- a/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap.bb
+++ b/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap.bb
@@ -1,0 +1,37 @@
+LICENSE = "CLOSED"
+RDEPENDS:${PN} += " avahi-daemon"
+
+inherit systemd features_check
+
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+SRC_URI += " \
+    file://tedge-identity \ 
+    file://tedge-bootstrap \
+    file://tedge-bootstrap.service \
+    file://tedge-avahi.service \
+"
+
+do_install () {
+    install -d "${D}${bindir}"
+    install -m 0755 "${WORKDIR}/tedge-identity" "${D}${bindir}"
+
+    install -d "${D}${bindir}"
+    install -m 0755 "${WORKDIR}/tedge-bootstrap" "${D}${bindir}"
+
+    install -d "${D}${systemd_system_unitdir}"
+    install -m 0644 "${WORKDIR}/tedge-bootstrap.service" "${D}${systemd_system_unitdir}"
+
+    # Enable service discovery
+    install -d "${D}${sysconfdir}/avahi/services"
+    install -m 0644 "${WORKDIR}/tedge-avahi.service" "${D}${sysconfdir}/avahi/services/"
+}
+
+FILES:${PN} += " \
+    ${bindir}/tedge-identity \
+    ${bindir}/tedge-bootstrap \
+    ${systemd_system_unitdir}/tedge-bootstrap.service \
+    ${sysconfdir}/avahi/services/tedge-avahi.service \
+"
+
+SYSTEMD_SERVICE:${PN} = "tedge-bootstrap.service"

--- a/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap/tedge-avahi.service
+++ b/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap/tedge-avahi.service
@@ -1,0 +1,19 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+    <name replace-wildcards="yes">thin-edge.io (%h)</name>
+    <service>
+        <type>_thin-edge_mqtt._tcp</type>
+        <port>1883</port>
+        <txt-record>topics=te/</txt-record>
+    </service>
+    <service>
+        <type>_thin-edge_http._tcp</type>
+        <port>8000</port>
+    </service>
+    <service>
+        <type>_thin-edge_c8y._tcp</type>
+        <port>8001</port>
+        <txt-record>topics=/c8y</txt-record>
+    </service>
+</service-group>

--- a/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap
+++ b/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+RAN_MARKER=/etc/tedge/.bootstrapped
+
+log() {
+    echo "$@" >&2
+}
+
+set_hostname() {
+    host_name="$1"
+    if [ "$(cat /etc/hostname)" = "$host_name" ]; then
+        echo "Host name is already set"
+        return
+    fi
+    echo "$host_name" | tee /etc/hostname
+    sed -i -E 's/^127.0.1.1.*/127.0.1.1\t'"$host_name"'/' /etc/hosts
+    hostnamectl set-hostname "$host_name"
+
+    if command -V systemctl >/dev/null 2>&1; then
+        systemctl restart avahi-daemon --no-block 2>/dev/null ||:
+    fi
+}
+
+# set hostname
+DEVICE_ID=
+attempt=0
+while [ "$attempt" -lt 30 ]; do
+    DEVICE_ID="$(tedge-identity ||:)"
+    if [ -n "$DEVICE_ID" ]; then
+        log "Found valid DEVICE_ID"
+        break
+    fi
+    attempt=$((attempt + 1))
+    log "Waiting for tedge-identity"
+    sleep 5
+done
+
+set_hostname "$DEVICE_ID"
+
+touch "$RAN_MARKER"

--- a/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap.service
+++ b/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap/tedge-bootstrap.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Set hostname on startup
+Wants=network-pre.target
+Before=network-pre.target
+ConditionPathExists=!/etc/tedge/.bootstrapped
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/tedge-bootstrap
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap/tedge-identity
+++ b/recipes-tedge-bin/tedge-bootstrap/tedge-bootstrap/tedge-identity
@@ -1,0 +1,95 @@
+#!/bin/sh
+set -eu
+
+IDENTITY_PREFIX=
+
+get_mac_address() {
+    SCN=/sys/class/net
+    min=65535
+    arphrd_ether=1
+    ifdev=
+
+    # find iface with lowest ifindex, skip non ARPHRD_ETHER types (lo, sit ...)
+    for dev in "$SCN"/*; do
+        if [ ! -f "$dev/type" ]; then
+            continue
+        fi
+
+        iftype=$(cat "$dev/type")
+        if [ "$iftype" -ne $arphrd_ether ]; then
+            continue
+        fi
+
+        # Skip dummy interfaces
+        if echo "$dev" | grep -q "$SCN/dummy" 2>/dev/null; then
+            continue
+        fi
+
+        idx=$(cat "$dev/ifindex")
+        if [ "$idx" -lt "$min" ]; then
+            min=$idx
+            ifdev=$dev
+        fi
+    done
+
+    if [ -z "$ifdev" ]; then
+        echo "no suitable interfaces found" >&2
+        exit 1
+    else
+        echo "using interface $ifdev" >&2
+        # grab MAC address
+        cat "$ifdev/address"
+    fi
+}
+
+get_model_type() {
+    MODEL=$(cat /proc/cpuinfo  | grep Model | cut -d: -f2 | xargs)
+    SERIAL_NO=$(cat /proc/cpuinfo  | grep Serial | cut -d: -f2 | xargs)
+
+    echo "Detected model: $MODEL" >&2
+    echo "Detected serial no.: $SERIAL_NO" >&2
+
+    MODEL_PREFIX=
+
+    case "$MODEL" in
+        Raspberry\ Pi\ 5*)
+            MODEL_PREFIX=rpi5
+            ;;
+        Raspberry\ Pi\ 4*)
+            MODEL_PREFIX=rpi4
+            ;;
+        Raspberry\ Pi\ 3*)
+            MODEL_PREFIX=rpi3
+            ;;
+        Raspberry\ Pi\ 2*)
+            MODEL_PREFIX=rpi2
+            ;;
+        Raspberry\ Pi\ Model*)
+            MODEL_PREFIX=rpi1
+            ;;
+        Raspberry\ Pi\ Zero\ 2\ W\ Rev*)
+            MODEL_PREFIX=rpizero2
+            ;;
+        Raspberry\ Pi\ Zero\ W\ Rev*)
+            MODEL_PREFIX=rpizero
+            ;;
+        *)
+            MODEL_PREFIX=unknown
+            ;;
+    esac
+    echo  "$MODEL_PREFIX"
+}
+
+MAC_ADDR=$(get_mac_address)
+MODEL=$(get_model_type)
+
+IDENTITY=
+
+if [ -n "$IDENTITY_PREFIX" ]; then
+    echo "Using identity prefix: $IDENTITY_PREFIX" >&2
+    IDENTITY=$(echo "${IDENTITY_PREFIX}-${MODEL}-${MAC_ADDR}" | tr -d ":")
+else
+    IDENTITY=$(echo "${MODEL}-${MAC_ADDR}" | tr -d ":")
+fi
+
+echo "$IDENTITY"

--- a/recipes-tedge-bin/tedge-firmware/tedge-firmware.bb
+++ b/recipes-tedge-bin/tedge-firmware/tedge-firmware.bb
@@ -1,0 +1,34 @@
+LICENSE = "CLOSED"
+
+SRC_URI += " \
+    file://mender_workflow.sh \ 
+    file://firmware_update.toml \
+    file://tedge-firmware \
+    file://persist.conf \
+"
+
+do_install () {
+    # Add firmware worfklow and script
+    install -d "${D}${bindir}"
+    install -m 0755 "${WORKDIR}/mender_workflow.sh" "${D}${bindir}"
+
+    install -d "${D}/etc/tedge/operations"
+    install -m 0644 "${WORKDIR}/firmware_update.toml" "${D}${sysconfdir}/tedge/operations"
+
+    # FIXME: This cases a conflict with the existing sudoers.d folder
+    # Allow sudo access
+    #install -d -m 0700 "${D}/etc/sudoers.d"
+    #install -m 0644 "${WORKDIR}/tedge-firmware" "${D}${sysconfdir}/sudoers.d/"
+
+    # mosquitto setup
+    install -d "${D}/var/lib/mosquitto"
+    install -d "${D}${sysconfdir}/tedge/mosquitto-conf/"
+    install -m 0644 "${WORKDIR}/persist.conf" "${D}${sysconfdir}/tedge/mosquitto-conf/"
+}
+
+FILES:${PN} += " \
+    ${bindir}/mender_workflow.sh \
+    ${sysconfdir}/tedge/operations/firmware_update.toml \
+    ${sysconfdir}/sudoers.d/tedge-firmware \
+    ${sysconfdir}/tedge/mosquitto-conf/persist.conf \
+"

--- a/recipes-tedge-bin/tedge-firmware/tedge-firmware/firmware_update.toml
+++ b/recipes-tedge-bin/tedge-firmware/tedge-firmware/firmware_update.toml
@@ -1,0 +1,49 @@
+operation = "firmware_update"
+
+[init]
+next = ["scheduled"]
+
+[scheduled]
+next = ["executing"]
+
+[executing]
+script = "/usr/bin/mender_workflow.sh executing --on-success download"
+next = ["download"]
+
+[download]
+script = "/usr/bin/mender_workflow.sh download --url ${.payload.remoteUrl} --on-success install --on-error failed"
+next = ["install"]
+
+[install]
+script = "/usr/bin/mender_workflow.sh install --url ${.payload.url} --on-success commit --on-restart restart --on-error failed"
+next = ["commit", "restart", "failed"]
+
+[restart]
+script = "restart"
+next = ["restarting", "restarted", "failed_restart"]
+
+[restarted]
+script = "/usr/bin/mender_workflow.sh restarted --on-success commit"
+next = ["commit"]
+
+[failed_restart]
+script = "/usr/bin/mender_workflow.sh failed_restart --on-success failed --on-error failed"
+next = ["failed"]
+
+[commit]
+script = "/usr/bin/mender_workflow.sh commit --firmware-name ${.payload.name} --firmware-version ${.payload.version} --url ${.payload.remoteUrl} --on-success successful --on-restart rollback_restart --on-error failed"
+next = ["successful", "rollback_restart"]
+
+[rollback_restart]
+script = "restart"
+next = ["restarting", "rollback_successful", "failed"]
+
+[rollback_successful]
+script = "/usr/bin/mender_workflow.sh rollback_successful --on-success failed"
+next = ["failed"]
+
+[successful]
+next = []
+
+[failed]
+next = []

--- a/recipes-tedge-bin/tedge-firmware/tedge-firmware/mender_workflow.sh
+++ b/recipes-tedge-bin/tedge-firmware/tedge-firmware/mender_workflow.sh
@@ -1,0 +1,279 @@
+#!/bin/sh
+set -e
+ON_SUCCESS="successful"
+ON_ERROR="failed"
+ON_RESTART="restart"
+FIRMWARE_NAME=
+FIRMWARE_VERSION=
+FIRMWARE_URL=
+FIRMWARE_META_FILE=/etc/tedge/.firmware
+MANUAL_DOWNLOAD=1
+
+ACTION="$1"
+shift
+
+log() {
+    msg="$(date +%Y-%m-%dT%H:%M:%S) [current=$ACTION] $*"
+    echo "$msg" >&2
+
+    # publish to pub for better resolution
+    current_partition=$(get_current_partition)
+    tedge mqtt pub -q 2 te/device/main///e/firmware_update "{\"text\":\"Firmware Workflow: [$ACTION] $*\",\"state\":\"$ACTION\",\"partition\":\"$current_partition\"}"
+    sleep 1
+}
+
+local_log() {
+    # Only log locally and don't push to the cloud
+    msg="$(date +%Y-%m-%dT%H:%M:%S) [current=$ACTION] $*"
+    echo "$msg" >&2
+}
+
+next_state_with_context() {
+    echo ":::begin-tedge:::"
+    echo "$1"
+    echo ":::end-tedge:::"
+    sleep 1
+}
+
+next_state() {
+    status="$1"
+    reason=
+
+    if [ $# -gt 1 ]; then
+        reason="$2"
+    fi
+
+    message=
+    if [ -n "$reason" ]; then
+        log "Moving to next State: $status. reason=$reason"
+        message=$(printf '{"status":"%s","reason":"%s"}' "$status" "$reason")
+    else
+        log "Moving to next State: $status"
+        message=$(printf '{"status":"%s"}' "$status")
+    fi
+
+    next_state_with_context "$message"
+    sleep 1
+}
+
+#
+# main
+#
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --firmware-name)
+            FIRMWARE_NAME="$2"
+            shift
+            ;;
+        --firmware-version)
+            FIRMWARE_VERSION="$2"
+            shift
+            ;;
+        --url)
+            FIRMWARE_URL="$2"
+            shift
+            ;;
+        --on-success)
+            ON_SUCCESS="$2"
+            shift
+            ;;
+        --on-error)
+            ON_ERROR="$2"
+            shift
+            ;;
+        --on-restart)
+            ON_RESTART="$2"
+            shift
+            ;;
+    esac
+    shift
+done
+
+wait_for_network() {
+    #
+    # Wait for network to be ready but don't block if still not available as the mender commit
+    # might be used to restore network connectivity.
+    #
+    attempt=0
+    max_attempts=10
+    # Network ready: 0 = no, 1 = yes
+    ready=0
+    local_log "Waiting for network to be ready, and time to be synced"
+
+    while [ "$attempt" -lt "$max_attempts" ]; do
+        # TIME_SYNC_ACTIVE=$(timedatectl | grep NTP | awk '{print $NF}')
+        TIME_IN_SYNC=$(timedatectl | awk '/System clock synchronized/{print $NF}')
+        case "${TIME_IN_SYNC}" in
+            yes)
+                ready=1
+                break
+                ;;
+        esac
+        attempt=$((attempt + 1))
+        local_log "Network not ready yet (attempt: $attempt from $max_attempts)"
+        sleep 30
+    done
+
+    # Duration can only be based on uptime since the device's clock might not be synced yet, so 'date' will not be monotonic
+    duration=$(awk '{print $1}' /proc/uptime)
+
+    local_log "Network: ready=$ready (after ${duration}s)"
+    if [ "$ready" = "1" ]; then
+        log "Network is ready after ${duration}s (from startup)"
+        return 0
+    fi
+
+    # Don't send cloud message if it is not ready
+    return 1
+}
+
+get_current_partition() {
+    MENDER_ROOTFS_PART_A="/dev/mmcblk0p2"
+    #MENDER_ROOTFS_PART_B="/dev/mmcblk0p3"
+    current=""
+    if mount | grep "${MENDER_ROOTFS_PART_A} on / " >/dev/null; then
+        current="A"
+    else
+        current="B"
+    fi
+    echo "$current"
+}
+
+get_next_partition() {
+    [ "$1" = "A" ] && echo "B" || echo "A"
+}
+
+executing() {
+    current_partition=$(get_current_partition)
+    next_partition=$(get_next_partition "$current_partition")
+    echo "---------------------------------------------------------------------------"
+    echo "Firmware update: $current_partition -> $next_partition"
+    echo "---------------------------------------------------------------------------"
+    log "Starting firmware update. Current partition is $(get_current_partition), so update will be applied to $next_partition"
+}
+
+download() {
+    status="$1"
+    url="$2"
+
+    MANUAL_DOWNLOAD=0
+
+    tedge_url="$url"
+
+    # Auto detect based on the url if the direct url can be used or not
+    case "$url" in
+        */inventory/binaries/*)
+            # FUTURE: The mender client 3.x currently checks for a Content-Length header in the response
+            # and fails if it is not present. Cumulocity IoT uses chunked Transfter-Encoding where the Content-Length
+            # is no included in the response headers, thus causing mender to fail.
+            # mender is currently being rewritten and seems to have support for proper Content-Range handling, however
+            # it is still in alpha.
+            #
+            MANUAL_DOWNLOAD=1
+
+            #
+            # Change url to a local url using the c8y proxy
+            #
+            partial_path=$(echo "$url" | sed 's|https://[^/]*/||g')
+            c8y_proxy_host=$(tedge config get c8y.proxy.client.host)
+            c8y_proxy_port=$(tedge config get c8y.proxy.client.port)
+            tedge_url="http://${c8y_proxy_host}:${c8y_proxy_port}/c8y/$partial_path"
+
+            log "Converted to local url: $url => $tedge_url"
+            ;;
+    esac
+
+    if [ "$MANUAL_DOWNLOAD" = 1 ]; then
+        # Removing any older files to ensure space for next file to download
+        # Note: busy box does not support -delete
+        TEDGE_DATA=$(tedge config get data.path)
+        find "$TEDGE_DATA" -name "*.firmware" -exec rm {} \;
+
+        last_part=$(echo "$partial_path" | rev | cut -d/ -f1 | rev)
+        local_file="$TEDGE_DATA/${last_part}.firmware"
+        log "Manually downloading artifact from $tedge_url and saving to $local_file"
+        wget -O "$local_file" "$tedge_url" >&2
+        log "Downloaded file from: $tedge_url"
+        next_state_with_context "$(printf '{"status":"%s","url":"%s"}\n' "$status" "$local_file")"
+    else
+        log "Using download url: $tedge_url"
+        next_state_with_context "$(printf '{"status":"%s","url":"%s"}\n' "$status" "$tedge_url")"
+    fi
+}
+
+install() {
+    url="$1"
+    log "Executing: mender install --reboot-exit-code '$url'"
+    EXIT_CODE=0
+    sudo mender install --reboot-exit-code "$url" || EXIT_CODE="$?"
+
+    case "$EXIT_CODE" in
+        0)
+            log "OK, no RESTART required"
+            next_state "$ON_SUCCESS"
+            ;;
+        4)
+            log "OK, RESTART required"
+            next_state "$ON_RESTART"
+            ;;
+        *)
+            log "ERROR. Unexpected mender return code"
+            next_state "$ON_ERROR"
+            ;;
+    esac
+}
+
+commit() {
+    log "Executing: mender commit"
+    EXIT_CODE=0
+    sudo mender commit || EXIT_CODE="$?"
+
+    case "$EXIT_CODE" in
+        0)
+            log "Commit successful. New default partition is $(get_current_partition)"
+
+            # Save firmware meta information to file (for reading on startup during normal operation)
+            local_log "Saving firmware info to $FIRMWARE_META_FILE"
+            printf 'FIRMWARE_NAME=%s\nFIRMWARE_VERSION=%s\nFIRMWARE_URL=%s\n' "$FIRMWARE_NAME" "$FIRMWARE_VERSION" "$FIRMWARE_URL" > "$FIRMWARE_META_FILE"
+
+            next_state "$ON_SUCCESS"
+            ;;
+        2)
+            log "Nothing to commit (update is not in progress)"
+            next_state "$ON_ERROR" "Nothing to commit. Either the boot loader triggered the rollback, the device was rebooted after switching to new partition, or someone did a manual commit or rollback!"
+            ;;
+        *)
+            log "Mender returned code: $EXIT_CODE. Rolling back to previous partition"
+            next_state "$ON_RESTART"
+            ;;
+    esac
+}
+
+case "$ACTION" in
+    executing)
+        executing
+        next_state "$ON_SUCCESS"
+        ;;
+    download) download "$ON_SUCCESS" "$FIRMWARE_URL"; ;;
+    install) install "$FIRMWARE_URL"; ;;
+    commit) commit; ;;
+    restarted)
+	    wait_for_network ||:
+        log "Device has been restarted...continuing workflow. partition=$(get_current_partition)"
+        next_state "$ON_SUCCESS"
+        ;;
+    rollback_successful)
+        next_state "$ON_SUCCESS" "Firmware update failed, but the rollback was successful. partition=$(get_current_partition)"
+        ;;
+    failed_restart)
+        # There is no success/failed action here, we always transition to the next state
+        # Only an error reason is added
+        next_state "$ON_SUCCESS" "Device failed to restart"
+        ;;
+    *)
+        log "Unknown command. This script only accecpts: download, install, commit, rollback, rollback_successful, failed_restart"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/recipes-tedge-bin/tedge-firmware/tedge-firmware/persist.conf
+++ b/recipes-tedge-bin/tedge-firmware/tedge-firmware/persist.conf
@@ -1,0 +1,2 @@
+persistence true
+persistence_location /data/mosquitto/

--- a/recipes-tedge-bin/tedge-firmware/tedge-firmware/tedge-firmware
+++ b/recipes-tedge-bin/tedge-firmware/tedge-firmware/tedge-firmware
@@ -1,0 +1,1 @@
+tedge  ALL = (ALL) NOPASSWD: /usr/bin/mender, /etc/tedge/operations/mender_workflow.sh, /usr/bin/tedgectl

--- a/recipes-tedge-bin/tedge/tedge.inc
+++ b/recipes-tedge-bin/tedge/tedge.inc
@@ -98,9 +98,37 @@ pkg_postinst_ontarget:${PN} () {
         fi
     fi
 
+    # FIXME: Add to recipe at build time rather than on first run
+    if [ -d /etc/sudoers.d/ ]; then
+        echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/mender, /usr/bin/tedgectl" > /etc/sudoers.d/tedge-firmware
+    fi
+
+    # Ensure persistence of operation state across partition swaps by storing
+    # information on a persisted mount
+    mkdir -p /data/tedge/agent
+    chown -R tedge:tedge /data/tedge/agent
+
+    # FIXME: Check if there is a better place to do this
+    if [ -d /var/lib/mosquitto ]; then
+        chown -R mosquitto:mosquitto /var/lib/mosquitto
+    fi
+
+    # FIXME: Currently some workflow state is reliant on the mosquitto db
+    # and there might be a race condition on startup after a partition swap
+    # where the existing mosquitto state is sometimes processed before the state
+    # stored under the /data/tedge/agent folder
+    # https://github.com/thin-edge/thin-edge.io/issues/2495
+    mkdir -p /data/mosquitto
+    chown mosquitto:mosquitto /data/mosquitto
+
     # Change log dir
-    tedge config set logs.path "/opt/log"
-    
+    mkdir -p "/data/tedge/log"
+    chown -R tedge:tedge "/data/tedge/log"
+    tedge config set logs.path "/data/tedge/log"
+
+    # Enable firmware management
+    tedge config set c8y.enable.firmware_update true
+
     # Initialize the tedge
     tedge init 
 

--- a/recipes-tedge-bin/tedge/tedge_0.13.x.bb
+++ b/recipes-tedge-bin/tedge/tedge_0.13.x.bb
@@ -1,0 +1,16 @@
+# Architecture variables
+ARCH_REPO_CHANNEL = "main"
+ARCH_VERSION = "0.13.2-rc118+g8457fa6"
+SRC_URI[aarch64.md5sum] = "d46ef8e2521cfd66e2c3d3aabc76b2de"
+SRC_URI[armv6.md5sum] = "7c37f84c989db0207ecdfcc8ab74d258"
+SRC_URI[armv7.md5sum] = "219b4977fdfa9e9cbeef23080580b636"
+SRC_URI[x86_64.md5sum] = "ac93c8fd77ab27f1e954412487ef5814"
+
+# Init manager variables
+INIT_REPO_CHANNEL = "community"
+INIT_VERSION = "0.2.2"
+SRC_URI[openrc.md5sum] = "7e8fdc361a868bc5602249879040e156"
+SRC_URI[systemd.md5sum] = "fd78bc692b823b56b660f528459d71d9"
+SRC_URI[sysvinit.md5sum] = "161568da4b2ff0dbbff4aa24f7e3fca2"
+
+require tedge.inc


### PR DESCRIPTION
Adding mender support using the firmware workflow

* Add mender state script which perform backup, restore and validation
* Add tedge-bootstrap scripts to change the hostname based on the device's hardware
* Add thin-edge.io workflow recipe (tedge-firmware)
