### PR TITLE
use fixed uid and gid for tedge and mosquitto users

### DIFF
--- a/recipes-core/images/core-image-tedge.bb
+++ b/recipes-core/images/core-image-tedge.bb
@@ -3,3 +3,12 @@ require recipes-core/images/core-image-base.bb
 IMAGE_INSTALL:append = " \
     tedge \
 "
+
+# Used fix uid/gid to avoid permission problems on /data
+inherit extrausers
+EXTRA_USERS_PARAMS += "\
+    groupadd --system --gid 950 tedge; \
+    useradd --system --no-create-home --shell /sbin/nologin --uid 951 --gid 950 tedge; \
+    groupmod -g 960 mosquitto; \
+    usermod -u 961 mosquitto; \
+"


### PR DESCRIPTION
Use fixed user id and group ids for the following users/groups to avoid ownership problems on the persistence partition, `/data`:
* tedge
* mosquitto