### PR TITLE
fix: only copy network manager if it exists in new partition

### DIFF
--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/transfer
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/transfer
@@ -178,7 +178,7 @@ else
 fi
 
 # Backup network manager connection config
-if [ -d /etc/NetworkManager/system-connections ]; then
+if [ -d "${target}/etc/NetworkManager/system-connections" ]; then
     networks=$(ls -l "/etc/NetworkManager/system-connections/"* 2>/dev/null | wc -l)
 
     if [ "$networks" -gt 0 ]; then


### PR DESCRIPTION
Only copy the network manager files to the new partition if it has network manager installed.