### PR TITLE
Add tedge inventory

### DIFF
--- a/recipes-core/images/core-image-tedge.bb
+++ b/recipes-core/images/core-image-tedge.bb
@@ -2,6 +2,8 @@ require recipes-core/images/core-image-base.bb
 
 IMAGE_INSTALL:append = " \
     tedge \
+    ${@bb.utils.contains('INIT_MANAGER','systemd','tedge-bootstrap','',d)} \
+    ${@bb.utils.contains('INIT_MANAGER','systemd','tedge-inventory','',d)} \
 "
 
 # Used fix uid/gid to avoid permission problems on /data

--- a/recipes-tedge-bin/tedge-inventory/tedge-inventory/firmware-version
+++ b/recipes-tedge-bin/tedge-inventory/tedge-inventory/firmware-version
@@ -1,0 +1,28 @@
+#!/bin/sh
+##################################################
+# Parse mender artifact to name and version
+#
+# Example file contents:
+# ```
+# core-image-tedge-mender-raspberrypi4-64_20231203.1232
+# ```
+##################################################
+set -e
+
+CURRENT_ARTIFACT=$(sudo mender show-artifact 2>/dev/null ||:)
+
+if [ -z "$CURRENT_ARTIFACT" ]; then
+    echo "mender show-artifact did not return a value" >&2
+    exit 0
+fi
+
+NAME=$(echo "$CURRENT_ARTIFACT" | rev | cut -d_ -f2- | rev)
+VERSION=$(echo "$CURRENT_ARTIFACT" | rev | cut -d_ -f1 | rev)
+
+echo "name=\"$NAME\""
+echo "version=\"$VERSION\""
+
+# FIXME: Workaround since thin-edge.io does deduplication detection.
+# However this is only needed because the firmware/name is cleared on tedge-agent startup.
+# Remove once https://github.com/thin-edge/thin-edge.io/issues/2497 is resolved
+echo "updated=\"$(date)\""

--- a/recipes-tedge-bin/tedge-inventory/tedge-inventory_git.bb
+++ b/recipes-tedge-bin/tedge-inventory/tedge-inventory_git.bb
@@ -10,6 +10,10 @@ PV = "0.1.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 
+SRC_URI += " \
+    file://firmware-version \
+"
+
 do_install () {
     install -d "${D}${datadir}/tedge-inventory"
     install -m 0755 "${S}/src/runner.sh" "${D}${datadir}/tedge-inventory"
@@ -18,6 +22,8 @@ do_install () {
     for file in ${S}/src/scripts.d/*; do
         install -m 0755 "$file" "${D}${datadir}/tedge-inventory/scripts.d"
     done
+
+    install -m 0755 "${WORKDIR}/firmware-version" "${D}${datadir}/tedge-inventory/scripts.d/80_c8y_Firmware"
 
     install -d "${D}${systemd_system_unitdir}"
     for file in ${S}/src/services/systemd/tedge-inventory*; do
@@ -31,4 +37,8 @@ SYSTEMD_SERVICE:${PN} = "tedge-inventory.timer"
 FILES:${PN} += " \
     ${systemd_system_unitdir}/tedge-inventory* \
     ${datadir}/tedge-inventory/* \
+"
+
+FILES:${PN} += " \
+    ${datadir}/tedge-inventory/scripts.d/firmware-version \
 "

--- a/recipes-tedge-bin/tedge-inventory/tedge-inventory_git.bb
+++ b/recipes-tedge-bin/tedge-inventory/tedge-inventory_git.bb
@@ -1,0 +1,34 @@
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10" 
+
+inherit systemd allarch
+
+SRC_URI += "git://git@github.com/thin-edge/tedge-inventory-plugin.git;protocol=https;branch=main"
+SRCREV = "${AUTOREV}"
+
+PV = "0.1.0+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+do_install () {
+    install -d "${D}${datadir}/tedge-inventory"
+    install -m 0755 "${S}/src/runner.sh" "${D}${datadir}/tedge-inventory"
+
+    install -d "${D}${datadir}/tedge-inventory/scripts.d"
+    for file in ${S}/src/scripts.d/*; do
+        install -m 0755 "$file" "${D}${datadir}/tedge-inventory/scripts.d"
+    done
+
+    install -d "${D}${systemd_system_unitdir}"
+    for file in ${S}/src/services/systemd/tedge-inventory*; do
+        install -m 0644 "$file" "${D}${systemd_system_unitdir}"
+    done
+
+}
+
+SYSTEMD_SERVICE:${PN} = "tedge-inventory.timer"
+
+FILES:${PN} += " \
+    ${systemd_system_unitdir}/tedge-inventory* \
+    ${datadir}/tedge-inventory/* \
+"


### PR DESCRIPTION
This PR adds `tedge-inventory` that can be used only with systemd as init manager.  It also comes with some improvements:

- `inherit allarch` won't rebuild recipes when architecture is changed (recipe must be arch independent)
- license is provided from `${COMMON_LICENSE_DIR}` 