### PR TITLE
fix: refresh service status after verify check

### DIFF
--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/verify-tedge
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/verify-tedge
@@ -36,4 +36,11 @@ if ! all_healthy; then
     exit "$RETRY_LATER"
 fi
 
+# FIXME: Trigger services to refresh their status to ensure the cloud will receive
+# the updated status.
+# Remove once https://github.com/thin-edge/thin-edge.io/issues/2498 is resolved
+TOPIC_ROOT=$(tedge config get mqtt.topic_root)
+TOPIC_ID=$(tedge config get mqtt.device_topic_id)
+tedge mqtt pub -q 1 -r "$TOPIC_ROOT/$TOPIC_ID/cmd/health/check" '{}'
+
 exit "$OK"


### PR DESCRIPTION
Trigger services to refresh their status to ensure the cloud will receive the updated status.

Remove once https://github.com/thin-edge/thin-edge.io/issues/2498 is resolved