### PR TITLE
trigger tedge-inventory after successful verification

### DIFF
--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/verify-tedge
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/verify-tedge
@@ -43,4 +43,12 @@ TOPIC_ROOT=$(tedge config get mqtt.topic_root)
 TOPIC_ID=$(tedge config get mqtt.device_topic_id)
 tedge mqtt pub -q 1 -r "$TOPIC_ROOT/$TOPIC_ID/cmd/health/check" '{}'
 
+# FIXME: Trigger tedge-inventory scripts as the status updates
+# are lost when the mosquitto bridge is down
+# Don't fail if the service does not exist, as this is not critical!
+if command -V systemctl >/dev/null 2>&1; then
+    echo "Triggering tedge-inventory scripts" >&2
+    systemctl start tedge-inventory ||:
+fi
+
 exit "$OK"


### PR DESCRIPTION
For unknown reasons the tedge-inventory messages are being lost on startup.