### PR TITLE
enforce mosquitto ownership of device certs in verify state script

### DIFF
--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/verify-tedge
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/verify-tedge
@@ -32,6 +32,10 @@ all_healthy() {
     return "$failed"
 }
 
+# Try fixing any possible mosquitto permissions first
+# In case if the pervious image uses different uid/gid for the mosquitto user
+chown mosquitto:mosquitto /etc/tedge/device-certs/* ||:
+
 if ! all_healthy; then
     exit "$RETRY_LATER"
 fi


### PR DESCRIPTION
Try changing the permissions of the device certificate (private/public key) in case if the previous image was using different uid/gid for the mosquitto user