### PR TITLE
fix: support updating bridge configuration across updates

### DIFF
--- a/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/restore
+++ b/mender/recipes-mender/tedge-state-scripts/tedge-state-scripts/restore
@@ -10,17 +10,15 @@ EXIT_OK=0
 #
 # reconnect mappers (to enforce regeneration of bridge files (to add/remove values as required))
 #
-# FIXME: Don't execute reconnect as reconnecting will restart the tedge-agent!
-# Enable once https://github.com/thin-edge/thin-edge.io/issues/2494 is resolved
-# MAPPERS="c8y az aws"
-# for name in $MAPPERS; do
-#     if [ -n "$(tedge config get "${name}.url" 2>/dev/null)" ]; then
-#         # Try reconnecting, but ignore any failures as it could be due to connectivity problems, and these are detected downstream
-#         # using a proper retry mechanism
-#         tedge reconnect "${name}" >&2 || true
-#     else
-#         echo "Skipping mapper as it is not configured. ${name}" >&2
-#     fi
-# done
+MAPPERS="c8y az aws"
+for name in $MAPPERS; do
+    if [ -n "$(tedge config get "${name}.url" 2>/dev/null)" ]; then
+        # Try reconnecting, but ignore any failures as it could be due to connectivity problems, and these are detected downstream
+        # using a proper retry mechanism
+        tedge reconnect "${name}" >&2 || true
+    else
+        echo "Skipping mapper as it is not configured. ${name}" >&2
+    fi
+done
 
 exit "$EXIT_OK"


### PR DESCRIPTION
Recreated the mosquitto bridge configuration on restoring state script. This enables the bridge config to be up to date to match the agents expected topic subscriptions.