### PR TITLE
feat: update to using thin-edge.io 1.0.0

### DIFF
--- a/recipes-tedge-bin/tedge/tedge_1.0.0.bb
+++ b/recipes-tedge-bin/tedge/tedge_1.0.0.bb
@@ -1,10 +1,10 @@
 # Architecture variables
 ARCH_REPO_CHANNEL = "release"
-ARCH_VERSION = "1.0.0-rc.1"
-SRC_URI[aarch64.md5sum] = "7dc35d241045e5445e2cb5a0a6ff6aaa"
-SRC_URI[armv6.md5sum] = "255deb0e2ec5fd87c80b9b2b89ef2ea6"
-SRC_URI[armv7.md5sum] = "a2549438177c4ec7ac61c0a2a48c02d7"
-SRC_URI[x86_64.md5sum] = "d4e12eb0e90815cb435bfeeeb82f2b71"
+ARCH_VERSION = "1.0.0"
+SRC_URI[aarch64.md5sum] = "daa8ad686a78e99458dc7e1dcafa21ad"
+SRC_URI[armv6.md5sum] = "bc7d9da45afe4d3bf4368f4a7874d208"
+SRC_URI[armv7.md5sum] = "15e8527ee551f48cb54bec3e988d9438"
+SRC_URI[x86_64.md5sum] = "f35f3374650cd084c326fd271e7f478e"
 
 # Init manager variables
 INIT_REPO_CHANNEL = "community"


### PR DESCRIPTION
Update checksums to use latest thin-edge.io 1.0.0 release