### PR TITLE
ci: add workflow to check for thin-edge.io updates and create a PR

### DIFF
--- a/.github/workflows/check_updates.yml
+++ b/.github/workflows/check_updates.yml
@@ -1,0 +1,35 @@
+name: check_updates
+on:
+  schedule:
+    # Check daily
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+jobs:
+  check_updates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set current date as env variable
+        run: |
+          echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
+          echo "PR_BRANCH=dep-update-$NOW" >> $GITHUB_ENV
+
+      - name: Check update
+        run: ./scripts/admin.sh update_version
+      - name: Check for changes
+        run: |
+          git add -A . ||:
+
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "No changes detected"
+            exit 0
+          fi
+          echo "Changes detected. Raising PR"
+
+          git config --global user.email "info@thin-edge.io"
+          git config --global user.name "Versioneer"
+          git checkout -b "$PR_BRANCH"
+          git commit -am "Update version"
+          git push --set-upstream origin "$PR_BRANCH"
+      - name: create pull request
+        run: gh pr create -B main -H "$PR_BRANCH" --title "Update version" --body "Update version"

--- a/.github/workflows/check_updates.yml
+++ b/.github/workflows/check_updates.yml
@@ -7,17 +7,16 @@ on:
 jobs:
   check_updates:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'thin-edge'
+    env:
+      PR_BRANCH: updater
     steps:
       - uses: actions/checkout@v4
-      - name: Set current date as env variable
-        run: |
-          echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
-          echo "PR_BRANCH=dep-update-$NOW" >> $GITHUB_ENV
-
       - name: Check update
         run: ./scripts/admin.sh update_version
       - name: Check for changes
         run: |
+          set -x
           git add -A . ||:
 
           if git diff --quiet && git diff --cached --quiet; then
@@ -25,11 +24,16 @@ jobs:
             exit 0
           fi
           echo "Changes detected. Raising PR"
-
+          git status
           git config --global user.email "info@thin-edge.io"
           git config --global user.name "Versioneer"
           git checkout -b "$PR_BRANCH"
           git commit -am "Update version"
-          git push --set-upstream origin "$PR_BRANCH"
+
       - name: create pull request
-        run: gh pr create -B main -H "$PR_BRANCH" --title "Update version" --body "Update version"
+        run: |
+          gh repo set-default ${{github.repository}}
+          gh pr create --title "Update version" --body "Update version"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+help() {
+    cat << EOT
+Project admin scripts to either update the thin-edge.io version
+
+USAGE
+    $0 <COMMAND> [OPTIONS]
+
+COMMANDS
+    $0 update_version          Update the BB layer for thin-edge.io to the latest version
+EOT
+}
+
+get_latest_version() {
+    repo="$1"
+    arch="$2"
+    cloudsmith ls pkg "$repo" -q "tag:latest AND name:tedge-$arch AND format:raw" -F json -l 1 \
+    | jq -r '.data[] | .version'
+}
+
+get_tedge_md5_checksum() {
+    repo="$1"
+    arch="$2"
+    version="$3"
+    cloudsmith ls pkg "$repo" -q "version:^$version$ AND name:tedge-$arch AND format:raw" -F json -l 1 \
+    | jq -r '.data[] | .files[0].checksum_md5'
+}
+
+get_services_latest_version() {
+    repo="$1"
+    cloudsmith ls pkg "$repo" -q "tag:latest AND name:tedge-openrc AND format:raw" -F json -l 1 \
+    | jq -r '.data[] | .version'
+}
+
+get_services_checksum() {
+    repo="$1"
+    version="$2"
+    pkg="$3"
+    cloudsmith ls pkg "$repo" -q "version:^$version$ AND name:$pkg AND format:raw" -F json -l 1 \
+    | jq -r '.data[] | .files[0].checksum_md5'
+}
+
+
+update_version() {
+    # Install tooling if missing
+    if ! [ -x "$(command -v cloudsmith)" ]; then
+        echo 'Install cloudsmith cli' >&2
+        if command -v pip3 &>/dev/null; then
+            pip3 install --upgrade cloudsmith-cli
+        elif command -v pip &>/dev/null; then
+            pip install --upgrade cloudsmith-cli
+        else
+            echo "Could not install cloudsmith cli. Reason: pip3/pip is not installed"
+            exit 2
+        fi
+    fi
+
+    echo "Updating version" >&2
+    # thin-edge.io
+    tedge_channel="release"
+    tedge_version=$(get_latest_version "thinedge/tedge-release" "arm64")
+    echo "Latest thin-edge.io version: $tedge_version in (thinedge/tedge-release)"
+
+    # tedge service definitions
+    community_repo="thinedge/community"
+    services_version=$(get_services_latest_version "$community_repo")
+    echo "Latest services repo version: $services_version in ($community_repo)"
+
+    # Generate BB file
+    tedge_bb_file="recipes-tedge-bin/tedge/tedge_${tedge_version}.bb"
+
+    echo "Writing bb file: $tedge_bb_file" >&2
+
+    cat << EOT | tee "$tedge_bb_file"
+# Architecture variables
+ARCH_REPO_CHANNEL = "$tedge_channel"
+ARCH_VERSION = "$tedge_version"
+SRC_URI[aarch64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "arm64" "$tedge_version")"
+SRC_URI[armv6.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}-armv6" "armv6" "$tedge_version")"
+SRC_URI[armv7.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "armv7" "$tedge_version")"
+SRC_URI[x86_64.md5sum] = "$(get_tedge_md5_checksum "thinedge/tedge-${tedge_channel}" "amd64" "$tedge_version")"
+
+# Init manager variables
+INIT_REPO_CHANNEL = "$(basename "$community_repo")"
+INIT_VERSION = "$services_version"
+SRC_URI[openrc.md5sum] = "$(get_services_checksum "$community_repo" "$services_version" "tedge-openrc")"
+SRC_URI[systemd.md5sum] = "$(get_services_checksum "$community_repo" "$services_version" "tedge-systemd")"
+SRC_URI[sysvinit.md5sum] = "$(get_services_checksum "$community_repo" "$services_version" "tedge-sysvinit-yocto")"
+
+require tedge.inc
+EOT
+}
+
+REST_ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            help
+            exit 0
+            ;;
+        --*|-*)
+            echo "Unknown option: $1" >&2
+            help
+            exit 1
+            ;;
+        *)
+            REST_ARGS+=("$1")
+            ;;
+    esac
+    shift
+done
+
+if [ ${#REST_ARGS[@]} -gt 0 ]; then
+    set -- "${REST_ARGS[@]}"
+fi
+
+if [ $# -eq 0 ]; then
+    echo "Missing required argument" >&2
+    help
+    exit 1
+fi
+
+COMMAND="$1"
+case "$COMMAND" in 
+    update_version)
+        update_version
+        ;;
+    *)
+        echo "Unknown command: $COMMAND" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Add a workflow which runs daily (or on demain) to check if there are any new thin-edge.io versions and will create/update the BB file and create a PR.

The functionality is provided in a new `admin.sh` script which uses cloudsmith api to check the latest version and updates the checksums. The workflow will rely on git change detection to see if a PR needs to be raised or not.